### PR TITLE
Make sure hex uses $_ in case bignum is used

### DIFF
--- a/lib/Authen/OATH.pm
+++ b/lib/Authen/OATH.pm
@@ -85,7 +85,7 @@ time is used. This is useful for testing purposes.
 
 sub totp {
     my ( $self, $secret, $manual_time ) = @_;
-    $secret = join( "", map chr( hex() ), $secret =~ /(..)/g )
+    $secret = join( "", map chr( hex($_) ), $secret =~ /(..)/g )
         if $secret =~ /^[a-fA-F0-9]{32,}$/;
     my $mod = $self->digest;
     if ( eval "require $mod" ) {
@@ -95,7 +95,7 @@ sub totp {
     my $T = Math::BigInt->new( int( $time / $self->timestep ) );
     die "Must request at least 6 digits" if $self->digits < 6;
     ( my $hex = $T->as_hex ) =~ s/^0x(.*)/"0"x(16 - length $1) . $1/e;
-    my $bin_code = join( "", map chr hex, $hex =~ /(..)/g );
+    my $bin_code = join( "", map chr( hex($_) ), $hex =~ /(..)/g );
     my $otp = $self->_process( $secret, $bin_code );
     return $otp;
 }
@@ -110,7 +110,7 @@ Both parameters are required.
 
 sub hotp {
     my ( $self, $secret, $c ) = @_;
-    $secret = join( "", map chr( hex() ), $secret =~ /(..)/g )
+    $secret = join( "", map chr( hex($_) ), $secret =~ /(..)/g )
         if $secret =~ /^[a-fA-F0-9]{32,}$/;
     my $mod = $self->digest;
     if ( eval "require $mod" ) {
@@ -119,7 +119,7 @@ sub hotp {
     $c = Math::BigInt->new($c);
     die "Must request at least 6 digits" if $self->digits < 6;
     ( my $hex = $c->as_hex ) =~ s/^0x(.*)/"0"x(16 - length $1) . $1/e;
-    my $bin_code = join( "", map chr hex, $hex =~ /(..)/g );
+    my $bin_code = join( "", map chr( hex($_) ), $hex =~ /(..)/g );
     my $otp = $self->_process( $secret, $bin_code );
     return $otp;
 }

--- a/t/02-bignum.t
+++ b/t/02-bignum.t
@@ -1,0 +1,55 @@
+#!perl
+
+use strict;
+use warnings;
+
+#
+# Same tests as 01-cases.t except use bignum first.
+#
+# On perl < 5.18 or bignum < 0.33 the overrides of
+# hex and oct were not scoped properly and would
+# interfere with certain uses of hex.
+# From perl5180delta:
+# "Using any of these three pragmata would cause hex
+# and oct anywhere else in the program to evaluate their
+# arguments in list context and prevent them from
+# inferring $_ when called without arguments."
+#
+
+use bignum;
+use Authen::OATH;
+use Digest::SHA;
+use Test::More;
+
+my $pwd  = '12345678901234567890';
+my $oath = Authen::OATH->new();
+my $OATH = Authen::OATH->new( 'digits' => 8 );
+ok( defined $oath,              'successfully created new object' );
+ok( $oath->isa('Authen::OATH'), 'correct class.' );
+ok( $oath->digits == 6,     'default digits set to 6' );
+ok(
+    $oath->digest eq 'Digest::SHA',
+    'default digest set to Digest::SHA'
+);
+ok( $oath->{'timestep'} == 30, 'default timestep set to 30' );
+
+print "Checking test vectors for totp()...\n";
+ok( $OATH->totp( $pwd, 59 ) eq '94287082' );
+ok( $OATH->totp( $pwd, 1111111109 ) eq '07081804' );
+ok( $OATH->totp( $pwd, 1111111111 ) eq '14050471' );
+ok( $OATH->totp( $pwd, 1234567890 ) eq '89005924' );
+ok( $OATH->totp( $pwd, 2000000000 ) eq '69279037' );
+
+print "Checking test vectors for hotp()...\n";
+ok( $oath->hotp( $pwd, 0 ) eq '755224' );
+ok( $oath->hotp( $pwd, 1 ) eq '287082' );
+ok( $oath->hotp( $pwd, 2 ) eq '359152' );
+ok( $oath->hotp( $pwd, 3 ) eq '969429' );
+ok( $oath->hotp( $pwd, 4 ) eq '338314' );
+ok( $oath->hotp( $pwd, 5 ) eq '254676' );
+ok( $oath->hotp( $pwd, 6 ) eq '287922' );
+ok( $oath->hotp( $pwd, 7 ) eq '162583' );
+ok( $oath->hotp( $pwd, 8 ) eq '399871' );
+ok( $oath->hotp( $pwd, 9 ) eq '520489' );
+
+done_testing();


### PR DESCRIPTION
On perl < 5.18 or bignum < 0.33 the overrides of hex and oct were not scoped properly and would interfere with certain uses of hex.

From perl5180delta:
"Using any of these three pragmata would cause hex and oct anywhere else in the program to evaluate their arguments in list context and prevent them from inferring $_ when called without arguments."